### PR TITLE
[FIX] issue with small buffer size

### DIFF
--- a/puppet/modules/nginx/templates/shopware.erb
+++ b/puppet/modules/nginx/templates/shopware.erb
@@ -158,8 +158,8 @@ location ~ \.php$ {
     fastcgi_param SHOPWARE_ENV    $shopware_env if_not_empty;
     fastcgi_param ENV             $shopware_env if_not_empty; # BC for older SW versions
 
-    fastcgi_buffers 8 16k;
-    fastcgi_buffer_size 32k;
+    fastcgi_buffers 8 128k;
+    fastcgi_buffer_size 256k;
 
     client_max_body_size 24M;
     client_body_buffer_size 128k;


### PR DESCRIPTION
This fixes an issue with 502 errors when using Shopware debug plugin and FirePHP.